### PR TITLE
Integrate react-router types

### DIFF
--- a/app/routes/a7k9m2x5p8w1n4q6r3y8b5t1/a7k9m2x5p8w1n4q6r3y8b5t1._index.tsx
+++ b/app/routes/a7k9m2x5p8w1n4q6r3y8b5t1/a7k9m2x5p8w1n4q6r3y8b5t1._index.tsx
@@ -12,6 +12,8 @@ import type { RouteMetadata } from '~/utils/route-types'
 import { requireUserWithMetadata } from '~/utils/route-utils.server'
 import { getLatinTitleClass } from '~/utils/rtlUtils'
 
+import type { Route } from './+types/a7k9m2x5p8w1n4q6r3y8b5t1._index'
+
 type LoaderData = {
   user: User
   teams: Array<{
@@ -26,11 +28,6 @@ type LoaderData = {
     startDate: Date
     endDate: Date | null
   }>
-}
-
-//! TODO: replace with generated type
-type LoaderArgs = {
-  request: Request
 }
 
 export const meta: MetaFunction = () => [
@@ -63,7 +60,7 @@ export const handle: RouteMetadata = {
   },
 }
 
-export async function loader({ request }: LoaderArgs): Promise<LoaderData> {
+export async function loader({ request }: Route.LoaderArgs): Promise<LoaderData> {
   // Enhanced protection automatically handles authentication and authorization
   const user = await requireUserWithMetadata(request, handle)
 

--- a/app/routes/a7k9m2x5p8w1n4q6r3y8b5t1/teams/teams._index.tsx
+++ b/app/routes/a7k9m2x5p8w1n4q6r3y8b5t1/teams/teams._index.tsx
@@ -14,15 +14,7 @@ import type { RouteMetadata } from '~/utils/route-types'
 import { requireUserWithMetadata } from '~/utils/route-utils.server'
 import { getLatinTitleClass } from '~/utils/rtlUtils'
 
-//! TODO: replace with generated type
-type LoaderArgs = {
-  request: Request
-}
-
-//! TODO: replace with generated type
-type ActionArgs = {
-  request: Request
-}
+import type { Route } from './+types/teams._index'
 
 // Route metadata - authenticated users can access
 export const handle: RouteMetadata = {
@@ -51,12 +43,12 @@ export const meta: MetaFunction = () => [
   { property: 'og:type', content: 'website' },
 ]
 
-export async function loader({ request }: LoaderArgs): Promise<TeamsLoaderData> {
+export async function loader({ request }: Route.LoaderArgs): Promise<TeamsLoaderData> {
   await requireUserWithMetadata(request, handle)
   return loadTeamsData(request)
 }
 
-export async function action({ request }: ActionArgs): Promise<Response> {
+export async function action({ request }: Route.ActionArgs): Promise<Response> {
   await requireUserWithMetadata(request, handle)
 
   const formData = await request.formData()

--- a/app/routes/a7k9m2x5p8w1n4q6r3y8b5t1/tournaments/tournaments.$tournamentId.tsx
+++ b/app/routes/a7k9m2x5p8w1n4q6r3y8b5t1/tournaments/tournaments.$tournamentId.tsx
@@ -16,17 +16,7 @@ import {
 import type { RouteMetadata } from '~/utils/route-types'
 import { requireUserWithMetadata } from '~/utils/route-utils.server'
 
-//! TODO: replace with generated type
-type LoaderArgs = {
-  request: Request
-  params: { tournamentId: string }
-}
-
-//! TODO: replace with generated type
-type ActionArgs = {
-  request: Request
-  params: { tournamentId: string }
-}
+import type { Route } from './+types/tournaments.$tournamentId'
 
 // Route metadata - admin only
 export const handle: RouteMetadata = {
@@ -83,7 +73,10 @@ type ActionData = {
   message?: string
 }
 
-export async function loader({ request, params }: LoaderArgs): Promise<LoaderData> {
+export async function loader({
+  request,
+  params,
+}: Route.LoaderArgs): Promise<LoaderData> {
   await requireUserWithMetadata(request, handle)
 
   // Read 'lang' cookie from request
@@ -115,7 +108,7 @@ export async function loader({ request, params }: LoaderArgs): Promise<LoaderDat
 export async function action({
   request,
   params,
-}: ActionArgs): Promise<Response | ActionData> {
+}: Route.ActionArgs): Promise<Response | ActionData> {
   await requireUserWithMetadata(request, handle)
 
   const { tournamentId } = params

--- a/app/routes/a7k9m2x5p8w1n4q6r3y8b5t1/tournaments/tournaments._index.tsx
+++ b/app/routes/a7k9m2x5p8w1n4q6r3y8b5t1/tournaments/tournaments._index.tsx
@@ -16,15 +16,7 @@ import type { RouteMetadata } from '~/utils/route-types'
 import { requireUserWithMetadata } from '~/utils/route-utils.server'
 import { getLatinTitleClass } from '~/utils/rtlUtils'
 
-//! TODO: replace with generated type
-type LoaderArgs = {
-  request: Request
-}
-
-//! TODO: replace with generated type
-type ActionArgs = {
-  request: Request
-}
+import type { Route } from './+types/tournaments._index'
 
 // Route metadata - authenticated users can access
 export const handle: RouteMetadata = {
@@ -57,7 +49,7 @@ type LoaderData = {
   tournamentListItems: TournamentListItem[]
 }
 
-export async function loader({ request }: LoaderArgs): Promise<LoaderData> {
+export async function loader({ request }: Route.LoaderArgs): Promise<LoaderData> {
   await requireUserWithMetadata(request, handle)
 
   const tournamentListItems = await getAllTournamentListItems()
@@ -65,7 +57,7 @@ export async function loader({ request }: LoaderArgs): Promise<LoaderData> {
   return { tournamentListItems }
 }
 
-export async function action({ request }: ActionArgs): Promise<Response> {
+export async function action({ request }: Route.ActionArgs): Promise<Response> {
   await requireUserWithMetadata(request, handle)
 
   const formData = await request.formData()

--- a/app/routes/a7k9m2x5p8w1n4q6r3y8b5t1/tournaments/tournaments.new.tsx
+++ b/app/routes/a7k9m2x5p8w1n4q6r3y8b5t1/tournaments/tournaments.new.tsx
@@ -12,15 +12,7 @@ import {
 import type { RouteMetadata } from '~/utils/route-types'
 import { requireUserWithMetadata } from '~/utils/route-utils.server'
 
-//! TODO: replace with generated type
-type LoaderArgs = {
-  request: Request
-}
-
-//! TODO: replace with generated type
-type ActionArgs = {
-  request: Request
-}
+import type { Route } from './+types/tournaments.new'
 
 // Route metadata - admin only
 export const handle: RouteMetadata = {
@@ -69,7 +61,7 @@ type ActionData = {
   message?: string
 }
 
-export async function loader({ request }: LoaderArgs): Promise<LoaderData> {
+export async function loader({ request }: Route.LoaderArgs): Promise<LoaderData> {
   await requireUserWithMetadata(request, handle)
 
   const divisions = getAllDivisions()
@@ -81,7 +73,9 @@ export async function loader({ request }: LoaderArgs): Promise<LoaderData> {
   }
 }
 
-export async function action({ request }: ActionArgs): Promise<Response | ActionData> {
+export async function action({
+  request,
+}: Route.ActionArgs): Promise<Response | ActionData> {
   await requireUserWithMetadata(request, handle)
 
   const formData = await request.formData()

--- a/app/routes/about.tsx
+++ b/app/routes/about.tsx
@@ -8,14 +8,11 @@ import { cn } from '~/utils/misc'
 import type { RouteMetadata } from '~/utils/route-types'
 import { getLatinTitleClass } from '~/utils/rtlUtils'
 
+import type { Route } from './+types/about'
+
 // Type definition for loader data
 type LoaderData = {
   version: string
-}
-
-//! TODO: replace with generated type
-type LoaderArgs = {
-  request: Request
 }
 
 // Route metadata - this is a public route
@@ -40,7 +37,9 @@ export const meta: MetaFunction = () => [
   { property: 'og:type', content: 'website' },
 ]
 
-export async function loader({ request: _request }: LoaderArgs): Promise<LoaderData> {
+export async function loader({
+  request: _request,
+}: Route.LoaderArgs): Promise<LoaderData> {
   // Read version from package.json
   const packageJson = await import('../../package.json')
   return { version: packageJson.version }

--- a/app/routes/auth/auth.signin.tsx
+++ b/app/routes/auth/auth.signin.tsx
@@ -18,14 +18,7 @@ import { getLatinTitleClass } from '~/utils/rtlUtils'
 import { createUserSession, getUser } from '~/utils/session.server'
 import { validateEmail } from '~/utils/utils'
 
-//! TODO: replace with generated type
-type LoaderArgs = {
-  request: Request
-}
-
-type ActionArgs = {
-  request: Request
-}
+import type { Route } from './+types/auth.signin'
 
 type ActionData = {
   errors?: {
@@ -40,7 +33,7 @@ export const handle: RouteMetadata = {
   title: 'common.titles.signIn',
 }
 
-export const loader = async ({ request }: LoaderArgs): Promise<object> => {
+export const loader = async ({ request }: Route.LoaderArgs): Promise<object> => {
   const user = await getUser(request)
   if (user) {
     // Always redirect all authorized users to Admin Panel
@@ -49,7 +42,7 @@ export const loader = async ({ request }: LoaderArgs): Promise<object> => {
   return {}
 }
 
-export const action = async ({ request }: ActionArgs): Promise<Response> => {
+export const action = async ({ request }: Route.ActionArgs): Promise<Response> => {
   const formData = await request.formData()
   const email = formData.get('email')
   const password = formData.get('password')

--- a/app/routes/auth/auth.signup.tsx
+++ b/app/routes/auth/auth.signup.tsx
@@ -18,14 +18,7 @@ import { getLatinTitleClass } from '~/utils/rtlUtils'
 import { getUserId } from '~/utils/session.server'
 import { safeRedirect, validateEmail } from '~/utils/utils'
 
-//! TODO: replace with generated type
-type LoaderArgs = {
-  request: Request
-}
-
-type ActionArgs = {
-  request: Request
-}
+import type { Route } from './+types/auth.signup'
 
 type ActionData = {
   errors?: {
@@ -42,7 +35,7 @@ export const handle: RouteMetadata = {
   title: 'common.titles.signUp',
 }
 
-export async function loader({ request }: LoaderArgs): Promise<object> {
+export async function loader({ request }: Route.LoaderArgs): Promise<object> {
   const userId = await getUserId(request)
   if (userId) {
     // If user is already logged in, redirect them to homepage
@@ -51,7 +44,7 @@ export async function loader({ request }: LoaderArgs): Promise<object> {
   return {}
 }
 
-export const action = async ({ request }: ActionArgs): Promise<Response> => {
+export const action = async ({ request }: Route.ActionArgs): Promise<Response> => {
   const formData = await request.formData()
   const email = formData.get('email')
   const password = formData.get('password')

--- a/app/routes/profile.tsx
+++ b/app/routes/profile.tsx
@@ -10,15 +10,12 @@ import type { RouteMetadata } from '~/utils/route-types'
 import { requireUserWithMetadata } from '~/utils/route-utils.server'
 import { getLatinTitleClass } from '~/utils/rtlUtils'
 
+import type { Route } from './+types/profile'
+
 // Route metadata - this is a protected route with enhanced configuration
 
 type LoaderData = {
   user: User
-}
-
-//! TODO: replace with generated type
-type LoaderArgs = {
-  request: Request
 }
 
 export const meta: MetaFunction = () => [
@@ -58,7 +55,7 @@ export const handle: RouteMetadata = {
   },
 }
 
-export async function loader({ request }: LoaderArgs): Promise<LoaderData> {
+export async function loader({ request }: Route.LoaderArgs): Promise<LoaderData> {
   // Use the enhanced protection system
   const user = await requireUserWithMetadata(request, handle)
   return { user }

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -10,15 +10,12 @@ import type { RouteMetadata } from '~/utils/route-types'
 import { getLatinTitleClass } from '~/utils/rtlUtils'
 import { requireUser } from '~/utils/session.server'
 
+import type { Route } from './+types/settings'
+
 // Route metadata - this is a protected route
 
 type LoaderData = {
   user: User
-}
-
-//! TODO: replace with generated type
-type LoaderArgs = {
-  request: Request
 }
 
 export const meta: MetaFunction = () => [
@@ -43,7 +40,7 @@ export const handle: RouteMetadata = {
   title: 'common.titles.settings',
 }
 
-export async function loader({ request }: LoaderArgs): Promise<LoaderData> {
+export async function loader({ request }: Route.LoaderArgs): Promise<LoaderData> {
   const user = await requireUser(request)
   return { user }
 }

--- a/app/routes/teams/teams.$teamId.tsx
+++ b/app/routes/teams/teams.$teamId.tsx
@@ -12,11 +12,7 @@ import { cn } from '~/utils/misc'
 import type { RouteMetadata } from '~/utils/route-types'
 import { getLatinTextClass, getLatinTitleClass } from '~/utils/rtlUtils'
 
-// Temporary types until auto-generation is complete
-export type LoaderArgs = {
-  params: Record<string, string | undefined>
-  request: Request
-}
+import type { Route } from './+types/teams.$teamId'
 
 type LoaderData = {
   team: {
@@ -32,7 +28,8 @@ export const handle: RouteMetadata = {
   isPublic: true,
 }
 
-export const meta: MetaFunction<typeof loader> = ({ data: loaderData }) => {
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  const loaderData = data as LoaderData | undefined
   if (!loaderData?.team) {
     return [
       { title: 'Team Not Found | Tournado' },
@@ -64,7 +61,7 @@ export const meta: MetaFunction<typeof loader> = ({ data: loaderData }) => {
   ]
 }
 
-export async function loader({ params }: LoaderArgs): Promise<LoaderData> {
+export async function loader({ params }: Route.LoaderArgs): Promise<LoaderData> {
   invariant(params.teamId, 'teamId not found')
 
   const team = await getTeamById({ id: params.teamId as string })

--- a/app/routes/teams/teams._index.tsx
+++ b/app/routes/teams/teams._index.tsx
@@ -11,10 +11,7 @@ import { cn } from '~/utils/misc'
 import type { RouteMetadata } from '~/utils/route-types'
 import { getLatinTitleClass } from '~/utils/rtlUtils'
 
-//! TODO: replace with generated type
-type LoaderArgs = {
-  request: Request
-}
+import type { Route } from './+types/teams._index'
 
 // Route metadata - this will inherit from the parent route
 export const handle: RouteMetadata = {
@@ -37,7 +34,7 @@ export const meta: MetaFunction = () => [
   { property: 'og:type', content: 'website' },
 ]
 
-export const loader = async ({ request }: LoaderArgs): Promise<TeamsLoaderData> =>
+export const loader = async ({ request }: Route.LoaderArgs): Promise<TeamsLoaderData> =>
   loadTeamsData(request)
 
 export default function PublicTeamsIndexPage(): JSX.Element {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/madrus/tournado.git"
   },
   "scripts": {
-    "build": "react-router build",
+    "build": "react-router typegen && react-router build",
     "prebuild": "prisma generate",
     "commit": "git add . && pnpm git-cz",
     "release": "standard-version",


### PR DESCRIPTION
## Summary
- generate route types during build
- replace manual placeholder LoaderArgs and ActionArgs with generated types

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685cd23f7aa48323b06aaaf8441ae6ea