### PR TITLE
Refine dark theme styles

### DIFF
--- a/app/components/AppBar.tsx
+++ b/app/components/AppBar.tsx
@@ -14,6 +14,7 @@ import {
   getArabicTextClass,
   getLatinTextClass,
   getLatinTitleClass,
+  getTypographyClass,
 } from '~/utils/rtlUtils'
 
 import { PrimaryNavLink } from './PrefetchLink'
@@ -187,7 +188,9 @@ export function AppBar({
 
         {/* Page title in center */}
         <div className='pointer-events-none absolute inset-0 flex items-center justify-center'>
-          <h2 className='text-center text-xl font-bold text-white sm:text-2xl'>
+          <h2
+            className={`text-center text-xl font-bold text-white sm:text-2xl ${getTypographyClass(currentLanguage)}`}
+          >
             {pageTitle}
           </h2>
         </div>

--- a/app/components/ThemeToggle.tsx
+++ b/app/components/ThemeToggle.tsx
@@ -1,12 +1,12 @@
 import type { JSX } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { useThemeStore } from '~/stores/useThemeStore'
+import { useSettingsStore } from '~/stores/useSettingsStore'
 import { renderIcon } from '~/utils/iconUtils'
 
 export function ThemeToggle(): JSX.Element {
   const { t } = useTranslation()
-  const { theme, toggleTheme } = useThemeStore()
+  const { theme, toggleTheme } = useSettingsStore()
 
   return (
     <button

--- a/app/components/UserMenu.tsx
+++ b/app/components/UserMenu.tsx
@@ -7,7 +7,7 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { useRTLDropdown } from '~/hooks/useRTLDropdown'
 import { IconName, renderIcon } from '~/utils/iconUtils'
 import { cn } from '~/utils/misc'
-import { getLatinTextClass } from '~/utils/rtlUtils'
+import { getLatinTextClass, getTypographyClass } from '~/utils/rtlUtils'
 
 export type MenuItemType = {
   label: string
@@ -113,7 +113,9 @@ export function UserMenu({
           <div className='px-4 py-3'>
             {authenticated ? (
               <div className={`text-emerald-800 ${menuClasses.textContainer}`}>
-                <p className='break-words'>{t('common.signedInAs')}</p>
+                <p className={`break-words ${getTypographyClass(i18n.language)}`}>
+                  {t('common.signedInAs')}
+                </p>
                 <p
                   className={`font-medium break-words text-emerald-800 ${getLatinTextClass(i18n.language)}`}
                 >
@@ -122,7 +124,7 @@ export function UserMenu({
               </div>
             ) : (
               <p
-                className={`text-emerald-800 ${menuClasses.textContainer} break-words`}
+                className={`text-emerald-800 ${menuClasses.textContainer} break-words ${getTypographyClass(i18n.language)}`}
               >
                 {t('common.welcome')}{' '}
                 <span
@@ -159,7 +161,11 @@ export function UserMenu({
                           renderIcon(item.icon, { className: 'w-5 h-5' })
                         ) : null}
                       </span>
-                      <span className={menuClasses.textContainer}>{item.label}</span>
+                      <span
+                        className={`${menuClasses.textContainer} ${getTypographyClass(i18n.language)}`}
+                      >
+                        {item.label}
+                      </span>
                     </button>
 
                     {languageMenuOpen ? (
@@ -167,9 +173,7 @@ export function UserMenu({
                         className={cn(
                           'ring-opacity-5 absolute z-30 mt-1 min-w-[8rem] rounded-md bg-white p-1 text-base shadow-lg ring-1 ring-black',
                           // Position submenu to the left of the language menu icon (mirrored for Arabic)
-                          isRTL ? '-end-16' : '-start-16',
-                          // Apply Arabic text scaling to the container when in Arabic mode
-                          i18n.language === 'ar' ? 'arabic-text' : ''
+                          isRTL ? '-end-16' : '-start-16'
                         )}
                       >
                         {item.subMenu.map((subItem, subIndex) => (
@@ -179,7 +183,7 @@ export function UserMenu({
                               subItem.active
                                 ? 'bg-emerald-50 text-emerald-700'
                                 : 'text-emerald-800 hover:bg-gray-50'
-                            } focus:outline-none ${menuClasses.menuItem} ${getLatinTextClass(i18n.language)}`}
+                            } focus:outline-none ${menuClasses.menuItem}`}
                             onClick={event => {
                               event.stopPropagation()
                               subItem.onClick()
@@ -197,7 +201,7 @@ export function UserMenu({
                               {subItem.customIcon}
                             </span>
                             <span
-                              className={`${menuClasses.textContainer} ${subItem.className || ''} ${getLatinTextClass(i18n.language)}`}
+                              className={`${menuClasses.textContainer} ${subItem.className || ''}`}
                             >
                               {subItem.label}
                             </span>
@@ -228,7 +232,11 @@ export function UserMenu({
                         ? renderIcon(item.icon, { className: 'w-5 h-5' })
                         : null}
                     </span>
-                    <span className={menuClasses.textContainer}>{item.label}</span>
+                    <span
+                      className={`${menuClasses.textContainer} ${getTypographyClass(i18n.language)}`}
+                    >
+                      {item.label}
+                    </span>
                     {item.todo ? (
                       <span className='ms-2 text-xs text-emerald-600'>(TODO)</span>
                     ) : null}

--- a/app/components/UserMenu.tsx
+++ b/app/components/UserMenu.tsx
@@ -165,11 +165,11 @@ export function UserMenu({
                     {languageMenuOpen ? (
                       <div
                         className={cn(
-                          'ring-opacity-5 absolute z-30 mt-1 min-w-[8rem] rounded-md bg-white p-1 shadow-lg ring-1 ring-black',
+                          'ring-opacity-5 absolute z-30 mt-1 min-w-[8rem] rounded-md bg-white p-1 text-base shadow-lg ring-1 ring-black',
                           // Position submenu to the left of the language menu icon (mirrored for Arabic)
                           isRTL ? '-end-16' : '-start-16',
-                          // Base text size
-                          'text-base'
+                          // Apply Arabic text scaling to the container when in Arabic mode
+                          i18n.language === 'ar' ? 'arabic-text' : ''
                         )}
                       >
                         {item.subMenu.map((subItem, subIndex) => (
@@ -179,11 +179,7 @@ export function UserMenu({
                               subItem.active
                                 ? 'bg-emerald-50 text-emerald-700'
                                 : 'text-emerald-800 hover:bg-gray-50'
-                            } focus:outline-none ${menuClasses.menuItem} !font-sans !text-base`}
-                            style={{
-                              fontSize: '16px',
-                              fontFamily: 'Inter, system-ui, sans-serif',
-                            }}
+                            } focus:outline-none ${menuClasses.menuItem} ${getLatinTextClass(i18n.language)}`}
                             onClick={event => {
                               event.stopPropagation()
                               subItem.onClick()
@@ -201,11 +197,7 @@ export function UserMenu({
                               {subItem.customIcon}
                             </span>
                             <span
-                              className={`${menuClasses.textContainer} ${subItem.className || ''}`}
-                              style={{
-                                fontSize: '16px',
-                                fontFamily: 'Inter, system-ui, sans-serif',
-                              }}
+                              className={`${menuClasses.textContainer} ${subItem.className || ''} ${getLatinTextClass(i18n.language)}`}
                             >
                               {subItem.label}
                             </span>

--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -7,6 +7,7 @@ import { initI18n } from './i18n/config'
 declare global {
   interface Window {
     __SSR_LANGUAGE__?: string
+    __SSR_THEME__?: string
   }
 }
 
@@ -36,7 +37,7 @@ if (isDevelopment) {
   }
 }
 
-// Use the SSR-injected language
+// Use the SSR-injected language and theme
 const lang = window.__SSR_LANGUAGE__ || 'nl'
 initI18n(lang)
 

--- a/app/hooks/useLanguageSwitcher.ts
+++ b/app/hooks/useLanguageSwitcher.ts
@@ -1,4 +1,4 @@
-import { useTranslation } from 'react-i18next'
+import { useSettingsStore } from '~/stores/useSettingsStore'
 
 type UseLanguageSwitcherReturn = {
   switchLanguage: (langCode: string) => void
@@ -7,19 +7,20 @@ type UseLanguageSwitcherReturn = {
 
 /**
  * Hook for switching languages in the application.
- * Only triggers i18n language change - persistence (localStorage + cookie)
- * is handled automatically by root.tsx when language changes.
+ * Updates the theme store which acts as the single source of truth.
+ * The store handles cookie and localStorage persistence automatically.
+ * The i18n instance will be updated automatically when the store changes.
  */
 export function useLanguageSwitcher(): UseLanguageSwitcherReturn {
-  const { i18n } = useTranslation()
+  const { language: storeLanguage, setLanguage } = useSettingsStore()
 
   const switchLanguage = (langCode: string) => {
-    // Only trigger i18n change - root.tsx will handle persistence
-    i18n.changeLanguage(langCode)
+    // Only update store - i18n will follow automatically
+    setLanguage(langCode as 'nl' | 'en' | 'ar' | 'tr')
   }
 
   return {
     switchLanguage,
-    currentLanguage: i18n.language,
+    currentLanguage: storeLanguage,
   }
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -235,6 +235,7 @@ export default function App({ loaderData }: Route.ComponentProps): JSX.Element {
   const { authenticated, username, user, ENV, language, tournaments } = loaderData
   const { setAuth } = useAuthStore()
   const { setAvailableOptionsField } = useTeamFormStore()
+  const { theme } = useThemeStore()
 
   // Handle auth store rehydration
   useAuthStoreHydration()
@@ -271,7 +272,13 @@ export default function App({ loaderData }: Route.ComponentProps): JSX.Element {
     <Document language={language}>
       <I18nextProvider i18n={i18n}>
         {/* Using "green" accent but overridden with emerald colors via CSS above */}
-        <Theme accentColor='green' grayColor='gray' radius='medium' scaling='100%'>
+        <Theme
+          accentColor='green'
+          grayColor='gray'
+          radius='medium'
+          scaling='100%'
+          appearance={theme}
+        >
           <div className='flex h-full flex-col'>
             <div className='relative' style={{ zIndex: 50 }}>
               <AppBar authenticated={authenticated} username={username} user={user} />
@@ -305,6 +312,7 @@ export default function App({ loaderData }: Route.ComponentProps): JSX.Element {
 
 export function ErrorBoundary(): JSX.Element {
   const { authenticated, username } = useAuthStore()
+  const { theme } = useThemeStore()
 
   // Handle auth store rehydration
   useAuthStoreHydration()
@@ -315,7 +323,13 @@ export function ErrorBoundary(): JSX.Element {
     <Document language='nl'>
       <I18nextProvider i18n={i18n}>
         {/* Using "green" accent but overridden with emerald colors via CSS above */}
-        <Theme accentColor='green' grayColor='gray' radius='medium' scaling='100%'>
+        <Theme
+          accentColor='green'
+          grayColor='gray'
+          radius='medium'
+          scaling='100%'
+          appearance={theme}
+        >
           <div className='flex h-full flex-col'>
             <div className='relative' style={{ zIndex: 50 }}>
               <AppBar authenticated={authenticated} username={username} />

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -93,14 +93,16 @@ export default function IndexPage(): JSX.Element {
       <div className='py-24 sm:py-32'>
         <div className='mx-auto max-w-7xl px-6 lg:px-8'>
           <div className='mx-auto max-w-2xl lg:text-center'>
-            <h2
+            <span
               className={cn(
-                'text-brand-dark text-base leading-7 font-semibold',
+                'block text-base leading-7 font-semibold text-red-500',
                 typography.centerAlign
               )}
+              role='heading'
+              aria-level={2}
             >
               {t('landing.features.title')}
-            </h2>
+            </span>
             <p
               className={cn(
                 'text-foreground-heading mt-2 text-3xl font-bold sm:text-4xl',

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -57,7 +57,7 @@ export default function IndexPage(): JSX.Element {
   return (
     <main className='flex h-full flex-col'>
       {/* Hero Section */}
-      <div className='flex flex-1 flex-col justify-center pt-16 pb-20'>
+      <div className='pt-16 pb-8'>
         <div className='mx-auto max-w-7xl px-6 lg:px-8'>
           <div className='mx-auto max-w-2xl text-center'>
             <h1

--- a/app/stores/__tests__/useSettingsStore.test.ts
+++ b/app/stores/__tests__/useSettingsStore.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useSettingsStore } from '../useSettingsStore'
+
+// Mock document.cookie
+Object.defineProperty(document, 'cookie', {
+  writable: true,
+  value: '',
+})
+
+// Helper to access store state
+const state = useSettingsStore.getState
+
+describe('useSettingsStore', () => {
+  beforeEach(() => {
+    // Reset store to initial state
+    state().resetStoreState()
+
+    // Clear document.cookie
+    document.cookie = ''
+
+    // Clear localStorage
+    localStorage.clear()
+
+    // Clear mocks
+    vi.clearAllMocks()
+  })
+
+  it('should initialize with default values', () => {
+    expect(state().theme).toBe('light')
+    expect(state().language).toBe('nl')
+  })
+
+  it('should set theme', () => {
+    state().setTheme('dark')
+
+    expect(state().theme).toBe('dark')
+  })
+
+  it('should toggle theme from light to dark', () => {
+    // Initially light
+    expect(state().theme).toBe('light')
+
+    state().toggleTheme()
+
+    expect(state().theme).toBe('dark')
+  })
+
+  it('should toggle theme from dark to light', () => {
+    // Set to dark first
+    state().setTheme('dark')
+    expect(state().theme).toBe('dark')
+
+    state().toggleTheme()
+
+    expect(state().theme).toBe('light')
+  })
+
+  it('should set language', () => {
+    state().setLanguage('en')
+
+    expect(state().language).toBe('en')
+  })
+
+  it('should set all supported languages', () => {
+    const languages: ('nl' | 'en' | 'ar' | 'tr')[] = ['nl', 'en', 'ar', 'tr']
+
+    languages.forEach(lang => {
+      state().setLanguage(lang)
+      expect(state().language).toBe(lang)
+    })
+  })
+
+  it('should persist theme to localStorage', () => {
+    state().setTheme('dark')
+
+    // Get the persisted data from localStorage
+    const persistedDataString = localStorage.getItem('settings-storage')
+    expect(persistedDataString).not.toBeNull()
+
+    if (persistedDataString) {
+      const persistedData = JSON.parse(persistedDataString)
+
+      // Zustand persist middleware wraps the state in a 'state' key and adds a version
+      expect(persistedData).toHaveProperty('state')
+      expect(persistedData).toHaveProperty('version')
+
+      // Check that the persisted state contains the expected values
+      expect(persistedData.state.theme).toBe('dark')
+    }
+  })
+
+  it('should persist language to localStorage', () => {
+    state().setLanguage('en')
+
+    // Get the persisted data from localStorage
+    const persistedDataString = localStorage.getItem('settings-storage')
+    expect(persistedDataString).not.toBeNull()
+
+    if (persistedDataString) {
+      const persistedData = JSON.parse(persistedDataString)
+
+      // Check that the persisted state contains the expected values
+      expect(persistedData.state.language).toBe('en')
+    }
+  })
+
+  it('should persist both theme and language changes', () => {
+    state().setTheme('dark')
+    state().setLanguage('tr')
+
+    // Get the persisted data from localStorage
+    const persistedDataString = localStorage.getItem('settings-storage')
+    expect(persistedDataString).not.toBeNull()
+
+    if (persistedDataString) {
+      const persistedData = JSON.parse(persistedDataString)
+
+      expect(persistedData.state.theme).toBe('dark')
+      expect(persistedData.state.language).toBe('tr')
+    }
+  })
+
+  it('should reset store state to initial values', () => {
+    // Change from defaults
+    state().setTheme('dark')
+    state().setLanguage('en')
+
+    expect(state().theme).toBe('dark')
+    expect(state().language).toBe('en')
+
+    // Reset
+    state().resetStoreState()
+
+    expect(state().theme).toBe('light')
+    expect(state().language).toBe('nl')
+  })
+
+  it('should handle multiple theme changes', () => {
+    expect(state().theme).toBe('light')
+
+    state().setTheme('dark')
+    expect(state().theme).toBe('dark')
+
+    state().setTheme('light')
+    expect(state().theme).toBe('light')
+
+    state().toggleTheme()
+    expect(state().theme).toBe('dark')
+
+    state().toggleTheme()
+    expect(state().theme).toBe('light')
+  })
+
+  it('should handle multiple language changes', () => {
+    expect(state().language).toBe('nl')
+
+    state().setLanguage('en')
+    expect(state().language).toBe('en')
+
+    state().setLanguage('ar')
+    expect(state().language).toBe('ar')
+
+    state().setLanguage('tr')
+    expect(state().language).toBe('tr')
+
+    state().setLanguage('nl')
+    expect(state().language).toBe('nl')
+  })
+})

--- a/app/stores/__tests__/useTournamentFormStore.test.ts
+++ b/app/stores/__tests__/useTournamentFormStore.test.ts
@@ -1,0 +1,486 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useTournamentFormStore } from '../useTournamentFormStore'
+
+// Mock the form validation utilities
+vi.mock('~/utils/form-validation', () => ({
+  validateSingleTournamentField: vi.fn(() => null),
+  validateEntireTournamentForm: vi.fn(() => ({})),
+}))
+
+// Helper to access store state
+const state = useTournamentFormStore.getState
+
+describe('useTournamentFormStore', () => {
+  beforeEach(() => {
+    // Reset store to initial state
+    state().resetStoreState()
+
+    // Clear sessionStorage
+    sessionStorage.clear()
+
+    // Clear mocks
+    vi.clearAllMocks()
+  })
+
+  describe('Initial State', () => {
+    it('should initialize with default form field values', () => {
+      expect(state().formFields.name).toBe('')
+      expect(state().formFields.location).toBe('')
+      expect(state().formFields.startDate).toBe('')
+      expect(state().formFields.endDate).toBe('')
+      expect(state().formFields.divisions).toEqual([])
+      expect(state().formFields.categories).toEqual([])
+    })
+
+    it('should initialize with default validation state', () => {
+      expect(state().validation.errors).toEqual({})
+      expect(state().validation.displayErrors).toEqual({})
+      expect(state().validation.serverErrors).toEqual({})
+      expect(state().validation.blurredFields).toEqual({})
+      expect(state().validation.submitAttempted).toBe(false)
+      expect(state().validation.forceShowAllErrors).toBe(false)
+    })
+
+    it('should initialize with default form metadata', () => {
+      expect(state().formMeta.mode).toBe('create')
+      expect(state().formMeta.isValid).toBe(false)
+      expect(state().availableOptions.divisions).toEqual([])
+      expect(state().availableOptions.categories).toEqual([])
+    })
+  })
+
+  describe('Form Field Management', () => {
+    it('should set individual form fields', () => {
+      state().setFormField('name', 'Test Tournament')
+      state().setFormField('location', 'Test Location')
+      state().setFormField('startDate', '2024-01-01')
+      state().setFormField('endDate', '2024-01-03')
+      state().setFormField('divisions', ['FIRST_DIVISION', 'SECOND_DIVISION'])
+      state().setFormField('categories', ['JO8', 'JO9'])
+
+      expect(state().formFields.name).toBe('Test Tournament')
+      expect(state().formFields.location).toBe('Test Location')
+      expect(state().formFields.startDate).toBe('2024-01-01')
+      expect(state().formFields.endDate).toBe('2024-01-03')
+      expect(state().formFields.divisions).toEqual([
+        'FIRST_DIVISION',
+        'SECOND_DIVISION',
+      ])
+      expect(state().formFields.categories).toEqual(['JO8', 'JO9'])
+    })
+
+    it('should set bulk form data', () => {
+      const formData = {
+        name: 'Bulk Tournament',
+        location: 'Bulk Location',
+        startDate: '2024-06-01',
+        divisions: ['FIRST_DIVISION'],
+      }
+
+      state().setFormData(formData)
+
+      expect(state().formFields.name).toBe('Bulk Tournament')
+      expect(state().formFields.location).toBe('Bulk Location')
+      expect(state().formFields.startDate).toBe('2024-06-01')
+      expect(state().formFields.divisions).toEqual(['FIRST_DIVISION'])
+    })
+
+    it('should reset form to initial state', () => {
+      // Set some form data
+      state().setFormField('name', 'Test Tournament')
+      state().setFormField('location', 'Test Location')
+      state().setValidationField('displayErrors', { name: 'Test error' })
+
+      // Reset form
+      state().resetStoreState()
+
+      // Check that form fields are reset
+      expect(state().formFields.name).toBe('')
+      expect(state().formFields.location).toBe('')
+      expect(state().validation.displayErrors).toEqual({})
+    })
+
+    it('should clear field error when setting form field', () => {
+      // Set an error first
+      state().setFieldError('name', 'Name is required')
+      expect(state().validation.displayErrors.name).toBe('Name is required')
+
+      // Set form field value should clear the error
+      state().setFormField('name', 'Test Tournament')
+      expect(state().validation.displayErrors.name).toBeUndefined()
+    })
+  })
+
+  describe('Field Value Helper', () => {
+    it('should get current field values correctly', () => {
+      // Set some values
+      state().setFormField('name', 'Test Tournament')
+      state().setFormField('location', 'Test Location')
+      state().setFormField('divisions', ['FIRST_DIVISION'])
+
+      expect(state().formFields.name).toBe('Test Tournament')
+      expect(state().formFields.location).toBe('Test Location')
+      expect(state().formFields.divisions).toEqual(['FIRST_DIVISION'])
+    })
+  })
+
+  describe('Reactive Validation System', () => {
+    it('should validate field immediately when touched', async () => {
+      // Mock validation to return error for empty field
+      const { validateSingleTournamentField } = vi.mocked(
+        await import('~/utils/form-validation')
+      )
+      vi.mocked(validateSingleTournamentField).mockReturnValue(
+        'tournaments.form.errors.nameRequired'
+      )
+
+      // Mark field as touched - should trigger validation immediately
+      state().validateFieldOnBlur('name')
+
+      // Since name is empty and now touched, should show error
+      expect(state().validation.displayErrors.name).toBe(
+        'tournaments.form.errors.nameRequired'
+      )
+      expect(state().validation.blurredFields.name).toBe(true)
+    })
+
+    it('should not show validation errors for untouched fields', () => {
+      // Validate field without touching it first
+      state().validateField('name')
+
+      // Should NOT show error because field is not touched and no flags are set
+      expect(state().validation.displayErrors.name).toBeUndefined()
+    })
+
+    it('should validate field when forceShowAllErrors is true', async () => {
+      // Mock validation to return error
+      const { validateSingleTournamentField } = vi.mocked(
+        await import('~/utils/form-validation')
+      )
+      vi.mocked(validateSingleTournamentField).mockReturnValue(
+        'tournaments.form.errors.nameRequired'
+      )
+
+      // Set force show all errors
+      state().setValidationField('forceShowAllErrors', true)
+
+      // Now validation should work even for untouched fields
+      state().validateField('name')
+      expect(state().validation.displayErrors.name).toBe(
+        'tournaments.form.errors.nameRequired'
+      )
+    })
+
+    it('should validate field when submitAttempted is true', async () => {
+      // Mock validation to return error
+      const { validateSingleTournamentField } = vi.mocked(
+        await import('~/utils/form-validation')
+      )
+      vi.mocked(validateSingleTournamentField).mockReturnValue(
+        'tournaments.form.errors.nameRequired'
+      )
+
+      // Set submit attempted
+      state().setValidationField('submitAttempted', true)
+
+      // Now validation should work even for untouched fields
+      state().validateField('name')
+      expect(state().validation.displayErrors.name).toBe(
+        'tournaments.form.errors.nameRequired'
+      )
+    })
+
+    it('should clear error when field becomes valid', async () => {
+      // Mock validation to first return error, then null
+      const { validateSingleTournamentField } = vi.mocked(
+        await import('~/utils/form-validation')
+      )
+      vi.mocked(validateSingleTournamentField).mockReturnValueOnce(
+        'tournaments.form.errors.nameRequired'
+      )
+
+      // Touch field and trigger error
+      state().validateFieldOnBlur('name')
+      expect(state().validation.displayErrors.name).toBe(
+        'tournaments.form.errors.nameRequired'
+      )
+
+      // Mock validation to return null for valid value
+      vi.mocked(validateSingleTournamentField).mockReturnValueOnce(null)
+
+      // Set valid value and validate again
+      state().setFormField('name', 'Valid Tournament')
+      state().validateField('name')
+
+      // Error should be cleared
+      expect(state().validation.displayErrors.name).toBeUndefined()
+    })
+  })
+
+  describe('Form Validation as Collection of Field Validations', () => {
+    it('should validate entire form and show all required field errors', async () => {
+      // Mock form validation to return errors for required fields
+      const { validateEntireTournamentForm } = vi.mocked(
+        await import('~/utils/form-validation')
+      )
+      const mockErrors = {
+        name: 'tournaments.form.errors.nameRequired',
+        location: 'tournaments.form.errors.locationRequired',
+        startDate: 'tournaments.form.errors.startDateRequired',
+        divisions: 'tournaments.form.errors.divisionsRequired',
+        categories: 'tournaments.form.errors.categoriesRequired',
+      }
+      vi.mocked(validateEntireTournamentForm).mockReturnValue(mockErrors)
+
+      // Form with missing required fields should be invalid
+      const isValid = state().validateForm()
+
+      expect(isValid).toBe(false)
+      expect(state().formMeta.isValid).toBe(false)
+      expect(state().validation.forceShowAllErrors).toBe(true) // Should be set during form validation
+
+      // All required fields should show errors
+      expect(state().validation.displayErrors.name).toBe(
+        'tournaments.form.errors.nameRequired'
+      )
+      expect(state().validation.displayErrors.location).toBe(
+        'tournaments.form.errors.locationRequired'
+      )
+      expect(state().validation.displayErrors.startDate).toBe(
+        'tournaments.form.errors.startDateRequired'
+      )
+      expect(state().validation.displayErrors.divisions).toBe(
+        'tournaments.form.errors.divisionsRequired'
+      )
+      expect(state().validation.displayErrors.categories).toBe(
+        'tournaments.form.errors.categoriesRequired'
+      )
+    })
+
+    it('should validate form as valid when all required fields are filled', async () => {
+      // Mock form validation to return no errors
+      const { validateEntireTournamentForm } = vi.mocked(
+        await import('~/utils/form-validation')
+      )
+      vi.mocked(validateEntireTournamentForm).mockReturnValue({})
+
+      // Fill all required fields
+      state().setFormField('name', 'Test Tournament')
+      state().setFormField('location', 'Test Location')
+      state().setFormField('startDate', '2024-01-01')
+      state().setFormField('divisions', ['FIRST_DIVISION'])
+      state().setFormField('categories', ['JO8'])
+
+      // Validate form
+      const isValid = state().validateForm()
+
+      expect(isValid).toBe(true)
+      expect(state().formMeta.isValid).toBe(true)
+      expect(Object.keys(state().validation.displayErrors)).toHaveLength(0)
+    })
+  })
+
+  describe('Field Error Management', () => {
+    it('should set and clear field errors', () => {
+      state().setFieldError('name', 'tournaments.form.errors.nameRequired')
+      expect(state().validation.displayErrors.name).toBe(
+        'tournaments.form.errors.nameRequired'
+      )
+
+      state().clearFieldError('name')
+      expect(state().validation.displayErrors.name).toBeUndefined()
+    })
+
+    it('should set validation errors in bulk', () => {
+      const errors = {
+        name: 'Required',
+        location: 'Too long',
+      }
+
+      state().setValidationField('errors', errors)
+      expect(state().validation.errors).toEqual(errors)
+    })
+
+    it('should set display errors in bulk', () => {
+      const errors = {
+        name: 'tournaments.form.errors.nameRequired',
+        location: 'tournaments.form.errors.locationRequired',
+      }
+
+      state().setValidationField('displayErrors', errors)
+      expect(state().validation.displayErrors).toEqual(errors)
+    })
+
+    it('should clear all errors', () => {
+      // Set multiple errors
+      state().setFieldError('name', 'Name is required')
+      state().setFieldError('location', 'Location is required')
+
+      // Clear all
+      state().clearAllErrors()
+
+      expect(state().validation.errors).toEqual({})
+      expect(state().validation.displayErrors).toEqual({})
+      expect(state().validation.serverErrors).toEqual({})
+    })
+  })
+
+  describe('Form Metadata', () => {
+    it('should set form mode', () => {
+      state().setFormMetaField('mode', 'edit')
+      expect(state().formMeta.mode).toBe('edit')
+    })
+
+    it('should set form validity', () => {
+      state().setFormMetaField('isValid', true)
+      expect(state().formMeta.isValid).toBe(true)
+    })
+
+    it('should set submit attempted flag', () => {
+      state().setValidationField('submitAttempted', true)
+      expect(state().validation.submitAttempted).toBe(true)
+    })
+
+    it('should set force show all errors flag', () => {
+      state().setValidationField('forceShowAllErrors', true)
+      expect(state().validation.forceShowAllErrors).toBe(true)
+    })
+  })
+
+  describe('Server Errors', () => {
+    it('should set server errors', () => {
+      const serverErrors = { name: 'Server error', location: 'Another error' }
+
+      state().setServerErrors(serverErrors)
+
+      expect(state().validation.serverErrors).toEqual(serverErrors)
+      expect(state().validation.displayErrors).toEqual(serverErrors)
+    })
+
+    it('should merge server errors with existing display errors', () => {
+      // Set display error first
+      state().setFieldError('name', 'Client error')
+
+      // Set server errors - this will merge with existing display errors
+      const serverErrors = { location: 'Server error' }
+      state().setServerErrors(serverErrors)
+
+      // Server errors are merged with existing display errors
+      expect(state().validation.displayErrors).toEqual({
+        name: 'Client error',
+        location: 'Server error',
+      })
+      expect(state().validation.serverErrors).toEqual({
+        location: 'Server error',
+      })
+    })
+  })
+
+  describe('Form Data Extraction', () => {
+    it('should return current form data in TournamentFormData format', () => {
+      // Set up form data
+      state().setFormField('name', 'Test Tournament')
+      state().setFormField('location', 'Test Location')
+      state().setFormField('startDate', '2024-01-01')
+      state().setFormField('endDate', '2024-01-03')
+      state().setFormField('divisions', ['FIRST_DIVISION'])
+      state().setFormField('categories', ['JO8'])
+
+      const formData = state().getFormData()
+
+      expect(formData).toEqual({
+        name: 'Test Tournament',
+        location: 'Test Location',
+        startDate: '2024-01-01',
+        endDate: '2024-01-03',
+        divisions: ['FIRST_DIVISION'],
+        categories: ['JO8'],
+      })
+    })
+  })
+
+  describe('Form State Helpers', () => {
+    it('should detect dirty form', () => {
+      // Initially not dirty
+      expect(state().isDirty()).toBe(false)
+
+      // Set data makes it dirty
+      state().setFormField('name', 'Test Tournament')
+      expect(state().isDirty()).toBe(true)
+    })
+
+    it('should not be dirty after setting form data', () => {
+      // setFormData updates both formFields and oldFormFields
+      state().setFormData({ name: 'Test Tournament' })
+
+      expect(state().isDirty()).toBe(false)
+    })
+  })
+
+  describe('Panel Validity', () => {
+    it('should check if panel is valid', () => {
+      // Panel validity depends on implementation - test basic functionality
+      const isPanel1Valid = state().isPanelValid(1)
+      expect(typeof isPanel1Valid).toBe('boolean')
+    })
+
+    it('should check if panel is enabled', () => {
+      // Panel enabled status depends on implementation - test basic functionality
+      const isPanel1Enabled = state().isPanelEnabled(1)
+      expect(typeof isPanel1Enabled).toBe('boolean')
+    })
+
+    it('should check if form is ready for submission', () => {
+      // Form submission readiness depends on implementation - test basic functionality
+      const isReady = state().isFormReadyForSubmission()
+      expect(typeof isReady).toBe('boolean')
+    })
+  })
+
+  describe('Persistence', () => {
+    it('should persist form data to sessionStorage', () => {
+      state().setFormField('name', 'Persistent Tournament')
+      state().setFormField('location', 'Persistent Location')
+
+      // Get the persisted data from sessionStorage
+      const persistedDataString = sessionStorage.getItem('TournamentFormStore')
+      expect(persistedDataString).not.toBeNull()
+
+      if (persistedDataString) {
+        const persistedData = JSON.parse(persistedDataString)
+
+        // Zustand persist middleware wraps the state in a 'state' key and adds a version
+        expect(persistedData).toHaveProperty('state')
+        expect(persistedData).toHaveProperty('version')
+
+        // Check that the persisted state contains the expected values
+        expect(persistedData.state.formFields.name).toBe('Persistent Tournament')
+        expect(persistedData.state.formFields.location).toBe('Persistent Location')
+
+        // Validation state should NOT be persisted
+        expect(persistedData.state.validation).toBeUndefined()
+      }
+    })
+
+    it('should only persist specific fields', () => {
+      state().setFormField('name', 'Test Tournament')
+      state().setFieldError('location', 'Required')
+
+      const persistedDataString = sessionStorage.getItem('TournamentFormStore')
+
+      if (persistedDataString) {
+        const persistedData = JSON.parse(persistedDataString)
+
+        // Should persist formFields and oldFormFields and formMeta.mode
+        expect(persistedData.state).toHaveProperty('formFields')
+        expect(persistedData.state).toHaveProperty('oldFormFields')
+        expect(persistedData.state).toHaveProperty('formMeta')
+        expect(persistedData.state.formMeta).toHaveProperty('mode')
+
+        // Should NOT persist validation state
+        expect(persistedData.state).not.toHaveProperty('validation')
+      }
+    })
+  })
+})

--- a/app/stores/useThemeStore.ts
+++ b/app/stores/useThemeStore.ts
@@ -42,10 +42,23 @@ export const useThemeStore = create<StoreState & Actions>()(
         resetStoreState: () => {
           set(initialStoreState, false, 'resetStoreState')
         },
-        setTheme: theme => set({ theme }, false, 'setTheme'),
+        setTheme: theme => {
+          // Persist to both localStorage and cookies for server-side access
+          if (isBrowser) {
+            document.cookie = `theme=${theme}; path=/; max-age=31536000`
+          }
+          set({ theme }, false, 'setTheme')
+        },
         toggleTheme: () =>
           set(
-            state => ({ theme: state.theme === 'light' ? 'dark' : 'light' }),
+            state => {
+              const newTheme = state.theme === 'light' ? 'dark' : 'light'
+              // Persist to cookies for server-side access
+              if (isBrowser) {
+                document.cookie = `theme=${newTheme}; path=/; max-age=31536000`
+              }
+              return { theme: newTheme }
+            },
             false,
             'toggleTheme'
           ),

--- a/app/styles/layout.css
+++ b/app/styles/layout.css
@@ -6,7 +6,11 @@ html {
 body {
   height: 100%;
   overflow-x: hidden;
-  background: linear-gradient(to bottom, rgb(236 253 245) 0%, rgb(220 252 231) 100%);
+  background: linear-gradient(
+    to bottom,
+    var(--gradient-from) 0%,
+    var(--gradient-to) 100%
+  );
 }
 
 /* Route transition styles */

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -28,14 +28,17 @@
 
 /* Dark mode color overrides */
 .dark {
-  --color-foreground: #ffffff; /* white text for dark mode */
-  --color-foreground-light: #ffffff; /* white text for dark mode */
+  --color-background: #111827; /* gray-900 */
+  --color-foreground: #e5e7eb; /* gray-200 body text */
+  --color-foreground-light: #d1d5db; /* gray-300 */
+  --color-foreground-lighter: #9ca3af; /* gray-400 */
+  --color-brand: #ef4444; /* red-500 */
   /* --color-brand-dark keeps its original red-700 value in both modes */
   --color-title: var(--color-accent); /* emerald-300 titles in dark mode */
   --gradient-from: #022c22; /* emerald-950 */
   --gradient-to: #065f46; /* emerald-800 */
   --footer-bg: #065f46; /* emerald-800 in dark mode */
-  --footer-text: #ffffff; /* white text in dark mode */
+  --footer-text: #e5e7eb; /* gray-200 */
 }
 
 /*

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -149,13 +149,13 @@
 .latin-title {
   font-family: system-ui, sans-serif !important;
   /* Fix letter spacing for titles in Arabic mode */
-  letter-spacing: -0.02em !important; /* Tighter letter spacing */
+  /* letter-spacing: -0.02em !important; Tighter letter spacing */
 }
 
 /* Specific fix for app name on home page in RTL context */
 [dir="rtl"] .app-name.latin-title {
   font-family: system-ui, sans-serif !important;
-  letter-spacing: -0.05em !important; /* Even tighter for the app name specifically */
+  /* letter-spacing: -0.05em !important; Even tighter for the app name specifically */
   /* Maintain consistent line height without conflicting with Tailwind classes */
   line-height: 1.5 !important; /* Match leading-normal from typography.appName */
   vertical-align: baseline !important; /* Prevent vertical shifting */
@@ -174,4 +174,62 @@
 [dir="rtl"] .ltr-override {
   direction: ltr;
   text-align: left;
+}
+
+/* User menu dropdown animation - synced with icon animation */
+[data-testid="user-menu-dropdown"] {
+  transform-origin: top;
+  animation-duration: 300ms;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  animation-fill-mode: forwards;
+}
+
+/* Opening animation */
+[data-testid="user-menu-dropdown"][data-state="open"] {
+  animation-name: menu-open;
+}
+
+/* Closing animation */
+[data-testid="user-menu-dropdown"][data-state="closed"] {
+  animation-name: menu-close;
+}
+
+@keyframes menu-open {
+  from {
+    opacity: 0;
+    transform: scaleY(0);
+  }
+  to {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+
+@keyframes menu-close {
+  from {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+  to {
+    opacity: 0;
+    transform: scaleY(0);
+  }
+}
+
+/* AppBar title Arabic text - needs higher specificity to override Tailwind size classes */
+[dir="rtl"] header .arabic-text.text-xl {
+  font-size: 1.5625rem !important; /* 25px = 20px * 1.25 */
+  transform: translateY(4px) !important; /* More downward adjustment */
+}
+
+[dir="rtl"] header .arabic-text.sm\:text-2xl {
+  font-size: 1.875rem !important; /* 30px = 24px * 1.25 */
+  transform: translateY(5px) !important; /* More downward adjustment for larger text */
+}
+
+@media (min-width: 640px) {
+  [dir="rtl"] header .arabic-text.sm\:text-2xl {
+    font-size: 1.875rem !important; /* 30px = 24px * 1.25 */
+    transform: translateY(5px) !important; /* More downward adjustment for larger text */
+  }
 }

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -14,13 +14,13 @@
   --color-accent: #a7f3d0; /* emerald-300 - for accents */
 
   /* Font family configuration */
-  --font-family-default: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-family-default: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --font-sans: var(--font-family-default);
 
   /* Background gradient variables */
   --gradient-from: #d1fae5; /* emerald-100 (one step darker than emerald-50) */
   --gradient-to: #f9fafb; /* gray-50 (one step darker than white) */
-  
+
   /* Footer background */
   --footer-bg: #ffffff; /* white */
   --footer-text: #374151; /* gray-700 */
@@ -120,20 +120,47 @@
 /* Script-aware typography system - clean and simple */
 
 /* Arabic text - for Arabic content in any context */
+.arabic-text.text-base,
 .arabic-text {
-  font-family: 'Amiri', system-ui, serif !important;
-  font-size: 1.25em !important;
+  font-family: 'Amiri', serif !important;
+  font-size: 1.25rem !important; /* Use rem to avoid em cascade issues */
 }
 
-/* Latin text - for Latin content in Arabic context (compensated size) */
-.latin-text {
-  font-family: 'Inter', system-ui, sans-serif !important;
-  font-size: 0.8em !important;
+/* Ensure Arabic text applies to all children unless overridden */
+.arabic-text * {
+  font-family: 'Amiri', serif !important;
+}
+
+/* Latin text - for Latin content in Arabic context */
+.latin-text,
+.arabic-text .latin-text {
+  font-family: system-ui, sans-serif !important;
+  font-size: 1rem !important; /* Use absolute size to match Latin mode */
+}
+
+/* Ensure Latin text style applies to children with higher specificity */
+.latin-text *,
+.arabic-text .latin-text * {
+  font-family: system-ui, sans-serif !important;
+  font-size: 1rem !important;
 }
 
 /* Latin titles - for Latin headings in Arabic context */
 .latin-title {
-  font-family: 'Inter', system-ui, sans-serif !important;
+  font-family: system-ui, sans-serif !important;
+  /* Fix letter spacing for titles in Arabic mode */
+  letter-spacing: -0.02em !important; /* Tighter letter spacing */
+}
+
+/* Specific fix for app name on home page in RTL context */
+[dir="rtl"] .app-name.latin-title {
+  font-family: system-ui, sans-serif !important;
+  letter-spacing: -0.05em !important; /* Even tighter for the app name specifically */
+  /* Maintain consistent line height without conflicting with Tailwind classes */
+  line-height: 1.5 !important; /* Match leading-normal from typography.appName */
+  vertical-align: baseline !important; /* Prevent vertical shifting */
+  display: block !important; /* Ensure consistent block-level behavior */
+  margin: 0 !important; /* Reset any unwanted margins */
 }
 
 /* RTL form inputs */


### PR DESCRIPTION
## Summary
- update dark color variables for better contrast
- use gradient CSS variables for body background
- sync Radix theme with Tailwind dark mode

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685e25369e78832398a5de99d9325ebc