### PR TITLE
Add dark mode support for admin panels

### DIFF
--- a/app/components/AdminPanel.tsx
+++ b/app/components/AdminPanel.tsx
@@ -21,44 +21,44 @@ const colorClasses = {
   emerald: {
     border: 'border-emerald-600',
     hoverBorder: 'hover:border-emerald-300',
-    hoverBg: 'hover:bg-emerald-50/30',
+    hoverBg: 'hover:bg-emerald-50/30 dark:hover:bg-emerald-900/30',
     focus: 'focus:ring-emerald-500',
     iconBorder: 'border-emerald-600',
     iconHoverBorder: 'group-hover:border-emerald-700',
-    iconHoverBg: 'group-hover:bg-emerald-50',
+    iconHoverBg: 'group-hover:bg-emerald-50 dark:group-hover:bg-emerald-900/40',
     titleHover: 'group-hover:text-emerald-700',
     textHover: 'group-hover:text-emerald-600',
   },
   blue: {
     border: 'border-blue-600',
     hoverBorder: 'hover:border-blue-300',
-    hoverBg: 'hover:bg-blue-50/30',
+    hoverBg: 'hover:bg-blue-50/30 dark:hover:bg-blue-900/30',
     focus: 'focus:ring-blue-500',
     iconBorder: 'border-blue-600',
     iconHoverBorder: 'group-hover:border-blue-700',
-    iconHoverBg: 'group-hover:bg-blue-50',
+    iconHoverBg: 'group-hover:bg-blue-50 dark:group-hover:bg-blue-900/40',
     titleHover: 'group-hover:text-blue-700',
     textHover: 'group-hover:text-blue-600',
   },
   gray: {
     border: 'border-gray-600',
     hoverBorder: 'hover:border-gray-300',
-    hoverBg: 'hover:bg-gray-50/30',
+    hoverBg: 'hover:bg-gray-50/30 dark:hover:bg-gray-700',
     focus: 'focus:ring-gray-500',
     iconBorder: 'border-gray-600',
     iconHoverBorder: 'group-hover:border-gray-700',
-    iconHoverBg: 'group-hover:bg-gray-50',
+    iconHoverBg: 'group-hover:bg-gray-50 dark:group-hover:bg-gray-700',
     titleHover: 'group-hover:text-gray-700',
     textHover: 'group-hover:text-gray-600',
   },
   red: {
     border: 'border-red-600',
     hoverBorder: 'hover:border-red-300',
-    hoverBg: 'hover:bg-red-50/30',
+    hoverBg: 'hover:bg-red-50/30 dark:hover:bg-red-900/30',
     focus: 'focus:ring-red-500',
     iconBorder: 'border-red-600',
     iconHoverBorder: 'group-hover:border-red-700',
-    iconHoverBg: 'group-hover:bg-red-50',
+    iconHoverBg: 'group-hover:bg-red-50 dark:group-hover:bg-red-900/40',
     titleHover: 'group-hover:text-red-700',
     textHover: 'group-hover:text-red-600',
   },
@@ -77,11 +77,10 @@ export function AdminPanel({
   const typographyClasses = getTypographyClasses(language)
   const colors = colorClasses[colorScheme]
 
-  const baseClassName = cn(
-    'group rounded-lg border bg-white p-6 shadow-sm transition-all duration-200 hover:shadow-md',
-    colors.hoverBorder,
-    colors.hoverBg
-  )
+  const panelBaseClasses =
+    'group rounded-lg border bg-white p-6 shadow-sm transition-all duration-200 hover:shadow-md dark:bg-gray-800 dark:border-gray-700'
+
+  const baseClassName = cn(panelBaseClasses, colors.hoverBorder, colors.hoverBg)
 
   const content = (
     <div

--- a/app/components/AdminPanel.tsx
+++ b/app/components/AdminPanel.tsx
@@ -78,7 +78,7 @@ export function AdminPanel({
   const colors = colorClasses[colorScheme]
 
   const panelBaseClasses =
-    'group rounded-lg border bg-white p-6 shadow-sm transition-all duration-200 hover:shadow-md dark:bg-gray-800 dark:border-gray-700'
+    'group rounded-lg border bg-white p-6 shadow-sm transition-all duration-200 hover:shadow-md dark:border-gray-700 dark:bg-gradient-to-b dark:from-gray-800 dark:to-gray-900 dark:text-gray-100'
 
   const baseClassName = cn(panelBaseClasses, colors.hoverBorder, colors.hoverBg)
 

--- a/app/components/TeamChip.tsx
+++ b/app/components/TeamChip.tsx
@@ -31,12 +31,12 @@ export function TeamChip({
   const isRtl = isRTL(i18n.language)
 
   const baseClasses = cn(
-    'inline-flex h-10 items-center rounded-lg border border-red-400 bg-white',
-    'font-semibold text-red-700 transition-all duration-300 ease-out relative overflow-hidden',
+    'inline-flex h-10 items-center rounded-lg border border-red-400 bg-white dark:border-red-600 dark:bg-red-950/20',
+    'font-semibold text-red-700 dark:text-red-300 transition-all duration-300 ease-out relative overflow-hidden',
     onClick && 'cursor-pointer',
     showActions && onDelete ? chipClasses.container : 'px-3',
     'hover:scale-105 active:scale-95',
-    'shadow-lg shadow-red-500/25 hover:shadow-xl hover:shadow-red-500/40 hover:bg-red-50/30 hover:border-red-500',
+    'shadow-lg shadow-red-500/25 hover:shadow-xl hover:shadow-red-500/40 hover:bg-red-50/30 dark:hover:bg-red-900/40 hover:border-red-500',
     'focus:ring-2 focus:ring-offset-2 focus:ring-red-600/90 focus:outline-none',
     'hover:ring-2 hover:ring-offset-2 hover:ring-red-600/90',
     className
@@ -50,7 +50,7 @@ export function TeamChip({
           event.stopPropagation()
           onDelete()
         }}
-        className='flex-shrink-0 rounded-full p-1 text-red-500 hover:bg-red-50 hover:text-red-700'
+        className='flex-shrink-0 rounded-full p-1 text-red-500 hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-900/40'
         aria-label={deleteAriaLabel || `Delete team ${team.clubName} ${team.teamName}`}
       >
         {renderIcon('close', { className: 'h-4 w-4' })}

--- a/app/components/TeamForm.tsx
+++ b/app/components/TeamForm.tsx
@@ -364,7 +364,9 @@ export function TeamForm({
           <div
             className={cn(
               'absolute top-8 -left-4 flex h-8 w-8 items-center justify-center rounded-full text-sm font-bold text-white shadow-lg lg:-left-6 rtl:-right-4 rtl:left-auto lg:rtl:-right-6',
-              isPanelEnabled(2) ? 'bg-blue-600' : 'bg-gray-400'
+              isPanelEnabled(2)
+                ? 'bg-blue-600 dark:bg-blue-700'
+                : 'bg-gray-400 dark:bg-gray-700'
             )}
           >
             2
@@ -374,8 +376,8 @@ export function TeamForm({
             className={cn(
               'rounded-xl border-2 p-6 shadow-lg transition-all duration-300 lg:p-8',
               isPanelEnabled(2)
-                ? 'border-blue-200 bg-gradient-to-br from-blue-50/50 to-cyan-50/30 hover:shadow-xl'
-                : 'border-gray-200 bg-gray-50'
+                ? 'border-blue-200 bg-gradient-to-br from-blue-50/50 to-cyan-50/30 hover:shadow-xl dark:border-blue-700 dark:from-blue-900/40 dark:to-cyan-900/20'
+                : 'border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800'
             )}
           >
             <div className='mb-6'>
@@ -383,7 +385,9 @@ export function TeamForm({
                 className={cn(
                   'mb-2 text-xl font-bold',
                   getLatinTitleClass(i18n.language),
-                  isPanelEnabled(2) ? 'text-blue-800' : 'text-gray-400'
+                  isPanelEnabled(2)
+                    ? 'text-blue-800 dark:text-blue-300'
+                    : 'text-gray-400 dark:text-gray-500'
                 )}
               >
                 {t('teams.form.teamInfo')}
@@ -391,7 +395,9 @@ export function TeamForm({
               <p
                 className={cn(
                   'text-sm',
-                  isPanelEnabled(2) ? 'text-blue-600' : 'text-gray-400'
+                  isPanelEnabled(2)
+                    ? 'text-blue-600 dark:text-blue-400'
+                    : 'text-gray-400 dark:text-gray-500'
                 )}
               >
                 {t('teams.form.enterTeamDetails')}
@@ -459,7 +465,9 @@ export function TeamForm({
           <div
             className={cn(
               'absolute top-8 -left-4 flex h-8 w-8 items-center justify-center rounded-full text-sm font-bold text-white shadow-lg lg:-left-6 rtl:-right-4 rtl:left-auto lg:rtl:-right-6',
-              isPanelEnabled(3) ? 'bg-green-600' : 'bg-gray-400'
+              isPanelEnabled(3)
+                ? 'bg-green-600 dark:bg-green-700'
+                : 'bg-gray-400 dark:bg-gray-700'
             )}
           >
             3
@@ -469,8 +477,8 @@ export function TeamForm({
             className={cn(
               'rounded-xl border-2 p-6 shadow-lg transition-all duration-300 lg:p-8',
               isPanelEnabled(3)
-                ? 'border-green-200 bg-gradient-to-br from-green-50/50 to-emerald-50/30 hover:shadow-xl'
-                : 'border-gray-200 bg-gray-50'
+                ? 'border-green-200 bg-gradient-to-br from-green-50/50 to-emerald-50/30 hover:shadow-xl dark:border-green-700 dark:from-green-900/40 dark:to-emerald-900/20'
+                : 'border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800'
             )}
           >
             <div className='mb-6'>
@@ -478,7 +486,9 @@ export function TeamForm({
                 className={cn(
                   'mb-2 text-xl font-bold',
                   getLatinTitleClass(i18n.language),
-                  isPanelEnabled(3) ? 'text-green-800' : 'text-gray-400'
+                  isPanelEnabled(3)
+                    ? 'text-green-800 dark:text-green-300'
+                    : 'text-gray-400 dark:text-gray-500'
                 )}
               >
                 {t('teams.form.teamLeaderInfo')}
@@ -486,7 +496,9 @@ export function TeamForm({
               <p
                 className={cn(
                   'text-sm',
-                  isPanelEnabled(3) ? 'text-green-600' : 'text-gray-400'
+                  isPanelEnabled(3)
+                    ? 'text-green-600 dark:text-green-400'
+                    : 'text-gray-400 dark:text-gray-500'
                 )}
               >
                 {t('teams.form.enterContactDetails')}
@@ -593,7 +605,9 @@ export function TeamForm({
             <div
               className={cn(
                 'absolute top-8 -left-4 flex h-8 w-8 items-center justify-center rounded-full text-sm font-bold text-white shadow-lg lg:-left-6 rtl:-right-4 rtl:left-auto lg:rtl:-right-6',
-                isPanelEnabled(4) ? 'bg-purple-600' : 'bg-gray-400'
+                isPanelEnabled(4)
+                  ? 'bg-purple-600 dark:bg-purple-700'
+                  : 'bg-gray-400 dark:bg-gray-700'
               )}
             >
               4
@@ -603,8 +617,8 @@ export function TeamForm({
               className={cn(
                 'rounded-xl border-2 p-6 shadow-lg transition-all duration-300 lg:p-8',
                 isPanelEnabled(4)
-                  ? 'border-purple-200 bg-gradient-to-br from-purple-50/50 to-indigo-50/30 hover:shadow-xl'
-                  : 'border-gray-200 bg-gray-50'
+                  ? 'border-purple-200 bg-gradient-to-br from-purple-50/50 to-indigo-50/30 hover:shadow-xl dark:border-purple-700 dark:from-purple-900/40 dark:to-indigo-900/20'
+                  : 'border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800'
               )}
             >
               <div className='mb-6'>
@@ -612,7 +626,9 @@ export function TeamForm({
                   className={cn(
                     'mb-2 text-xl font-bold',
                     getLatinTitleClass(i18n.language),
-                    isPanelEnabled(4) ? 'text-purple-800' : 'text-gray-400'
+                    isPanelEnabled(4)
+                      ? 'text-purple-800 dark:text-purple-300'
+                      : 'text-gray-400 dark:text-gray-500'
                   )}
                 >
                   {t('teams.form.privacyPolicy')}
@@ -620,7 +636,9 @@ export function TeamForm({
                 <p
                   className={cn(
                     'text-sm',
-                    isPanelEnabled(4) ? 'text-purple-600' : 'text-gray-400'
+                    isPanelEnabled(4)
+                      ? 'text-purple-600 dark:text-purple-400'
+                      : 'text-gray-400 dark:text-gray-500'
                   )}
                 >
                   {t('teams.form.readAndAccept')}
@@ -631,13 +649,13 @@ export function TeamForm({
                 className={cn(
                   'flex cursor-pointer items-start gap-3 rounded-lg border-2 p-4 transition-all duration-300',
                   privacyAgreement
-                    ? 'border-purple-500 bg-purple-50 text-purple-800'
+                    ? 'border-purple-500 bg-purple-50 text-purple-800 dark:border-purple-600 dark:bg-purple-900/30 dark:text-purple-300'
                     : getTranslatedError(
                           'privacyAgreement',
                           isPublicSuccess || !isPanelEnabled(4)
                         )
-                      ? 'border-red-500 bg-red-50 text-red-800'
-                      : 'border-gray-200 bg-white hover:border-purple-300 hover:bg-purple-50'
+                      ? 'border-red-500 bg-red-50 text-red-800 dark:border-red-600 dark:bg-red-900/30 dark:text-red-300'
+                      : 'border-gray-200 bg-white hover:border-purple-300 hover:bg-purple-50 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-purple-900/40'
                 )}
               >
                 <div className='relative flex-shrink-0'>
@@ -657,8 +675,8 @@ export function TeamForm({
                               'privacyAgreement',
                               isPublicSuccess || !isPanelEnabled(4)
                             )
-                          ? 'border-red-500 bg-red-50'
-                          : 'border-gray-300 bg-white'
+                          ? 'border-red-500 bg-red-50 dark:border-red-600 dark:bg-red-900/30'
+                          : 'border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-700'
                     )}
                     required
                     disabled={isPublicSuccess || !isPanelEnabled(4)}
@@ -672,7 +690,7 @@ export function TeamForm({
                 </div>
                 <span
                   className={cn(
-                    'text-lg font-normal text-gray-600',
+                    'text-lg font-normal text-gray-600 dark:text-gray-300',
                     getLatinTextClass(i18n.language)
                   )}
                 >
@@ -683,7 +701,7 @@ export function TeamForm({
                 'privacyAgreement',
                 isPublicSuccess || !isPanelEnabled(4)
               ) ? (
-                <p className='mt-2 text-sm text-red-600'>
+                <p className='mt-2 text-sm text-red-600 dark:text-red-400'>
                   {getTranslatedError(
                     'privacyAgreement',
                     isPublicSuccess || !isPanelEnabled(4)

--- a/app/routes/a7k9m2x5p8w1n4q6r3y8b5t1/tournaments/tournaments._index.tsx
+++ b/app/routes/a7k9m2x5p8w1n4q6r3y8b5t1/tournaments/tournaments._index.tsx
@@ -79,7 +79,7 @@ export default function AdminTournamentsIndexPage(): JSX.Element {
   const revalidator = useRevalidator()
 
   const cardClass =
-    'rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800'
+    'rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gradient-to-b dark:from-gray-800 dark:to-gray-900 dark:text-gray-100'
 
   // Track if we're on desktop for conditional rendering
   const [isDesktop, setIsDesktop] = useState(false)

--- a/app/routes/a7k9m2x5p8w1n4q6r3y8b5t1/tournaments/tournaments._index.tsx
+++ b/app/routes/a7k9m2x5p8w1n4q6r3y8b5t1/tournaments/tournaments._index.tsx
@@ -78,6 +78,9 @@ export default function AdminTournamentsIndexPage(): JSX.Element {
   const submit = useSubmit()
   const revalidator = useRevalidator()
 
+  const cardClass =
+    'rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800'
+
   // Track if we're on desktop for conditional rendering
   const [isDesktop, setIsDesktop] = useState(false)
 
@@ -288,7 +291,7 @@ export default function AdminTournamentsIndexPage(): JSX.Element {
     <div className='space-y-6'>
       {/* Stats using Radix Grid */}
       <Grid columns={{ initial: '1', sm: '3' }} gap='5' width='auto'>
-        <Box className='rounded-lg border border-gray-200 bg-white p-6 shadow-sm'>
+        <Box className={cardClass}>
           <Flex align='center'>
             <Box className='flex-shrink-0'>
               <Box className='flex h-8 w-8 items-center justify-center rounded-md bg-red-500'>
@@ -318,7 +321,7 @@ export default function AdminTournamentsIndexPage(): JSX.Element {
       </Grid>
 
       {/* Tournaments List */}
-      <Box className='w-full rounded-lg border border-gray-200 bg-white p-6 shadow-sm md:w-fit'>
+      <Box className={cn(cardClass, 'w-full md:w-fit')}>
         <Box className='mb-6'>
           <Heading as='h2' size='6' className={cn(getLatinTitleClass(i18n.language))}>
             {t('admin.tournaments.allTournaments')}
@@ -330,7 +333,7 @@ export default function AdminTournamentsIndexPage(): JSX.Element {
 
         {tournamentListItems.length === 0 ? (
           <Box className='py-12 text-center'>
-            <Box className='mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-gray-100'>
+            <Box className='mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800/60'>
               <TrophyIcon className='text-gray-400' size={24} variant='outlined' />
             </Box>
             <Text size='4' weight='medium' className='mb-2 text-gray-900'>
@@ -344,7 +347,7 @@ export default function AdminTournamentsIndexPage(): JSX.Element {
           <div className='w-full md:w-fit md:max-w-full'>
             {/* Header - only show on desktop */}
             {isDesktop ? (
-              <div className='rounded-t-lg border-b border-gray-200 bg-gray-50 px-6 py-3'>
+              <div className='rounded-t-lg border-b border-gray-200 bg-gray-50 px-6 py-3 dark:border-gray-700 dark:bg-gray-700'>
                 <div className='grid grid-cols-[2fr_1fr_1fr_auto] gap-6'>
                   <Text
                     size='1'
@@ -404,7 +407,9 @@ export default function AdminTournamentsIndexPage(): JSX.Element {
                   key={tournament.id}
                   className={cn(
                     'relative overflow-hidden',
-                    isDesktop ? 'border-b border-gray-100' : 'border-b border-gray-100',
+                    isDesktop
+                      ? 'border-b border-gray-100 dark:border-gray-700'
+                      : 'border-b border-gray-100 dark:border-gray-700',
                     index === tournamentListItems.length - 1 &&
                       'rounded-b-lg border-b-0'
                   )}
@@ -418,7 +423,7 @@ export default function AdminTournamentsIndexPage(): JSX.Element {
                     >
                       {/* Main content - fixed width */}
                       <div
-                        className='w-full flex-shrink-0 cursor-pointer bg-white transition-colors hover:bg-gray-50'
+                        className='w-full flex-shrink-0 cursor-pointer bg-white transition-colors hover:bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-700'
                         onClick={() => handleTournamentClick(tournament.id)}
                       >
                         <div className='px-6 py-4'>
@@ -475,7 +480,7 @@ export default function AdminTournamentsIndexPage(): JSX.Element {
                   ) : (
                     // Desktop: Table-like grid layout with improved column sizing
                     <div
-                      className='grid cursor-pointer grid-cols-[2fr_1fr_1fr_auto] gap-6 bg-white px-6 py-4 transition-colors hover:bg-gray-50'
+                      className='grid cursor-pointer grid-cols-[2fr_1fr_1fr_auto] gap-6 bg-white px-6 py-4 transition-colors hover:bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-700'
                       onClick={() => handleTournamentClick(tournament.id)}
                     >
                       <Box>
@@ -504,7 +509,7 @@ export default function AdminTournamentsIndexPage(): JSX.Element {
                             event.stopPropagation()
                             handleTournamentDelete(tournament.id)
                           }}
-                          className='flex min-w-32 items-center justify-center rounded-full p-1 text-red-600 transition-colors duration-200 hover:bg-red-50 hover:text-red-700'
+                          className='flex min-w-32 items-center justify-center rounded-full p-1 text-red-600 transition-colors duration-200 hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-900/40'
                           title={t('tournaments.deleteTournament')}
                         >
                           <DeleteIcon className='h-4 w-4' />

--- a/app/routes/teams/teams.$teamId.tsx
+++ b/app/routes/teams/teams.$teamId.tsx
@@ -79,6 +79,9 @@ export default function TeamDetailsPage(): JSX.Element {
   const { team } = useLoaderData<LoaderData>()
   const { i18n } = useTranslation()
 
+  const cardClass =
+    'rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800'
+
   return (
     <div className='min-h-screen'>
       <div className='mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8'>
@@ -97,7 +100,7 @@ export default function TeamDetailsPage(): JSX.Element {
           {/* Main Content - Games & Schedule */}
           <div className='space-y-6 lg:col-span-2'>
             {/* Upcoming Games */}
-            <div className='rounded-lg border border-gray-200 bg-white p-6 shadow-sm'>
+            <div className={cardClass}>
               <h2
                 className={cn(
                   'mb-4 text-xl font-semibold',
@@ -106,9 +109,11 @@ export default function TeamDetailsPage(): JSX.Element {
               >
                 🏐 Upcoming Games
               </h2>
-              <div className='rounded-lg border border-blue-200 bg-blue-50 p-4'>
-                <p className='font-medium text-blue-800'>🚧 Coming Soon!</p>
-                <p className='mt-1 text-sm text-blue-700'>
+              <div className='rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-700 dark:bg-blue-900/40'>
+                <p className='font-medium text-blue-800 dark:text-blue-300'>
+                  🚧 Coming Soon!
+                </p>
+                <p className='mt-1 text-sm text-blue-700 dark:text-blue-300'>
                   Team schedule and game management will be implemented here. This will
                   show upcoming matches, match results, and tournament standings.
                 </p>
@@ -116,7 +121,7 @@ export default function TeamDetailsPage(): JSX.Element {
 
               {/* Placeholder for future games list */}
               <div className='mt-4 space-y-3'>
-                <div className='rounded-lg border border-gray-200 bg-gray-50 p-4'>
+                <div className='rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-700'>
                   <div className='flex items-center justify-between'>
                     <div>
                       <p className='font-medium'>vs Team Example</p>
@@ -127,13 +132,13 @@ export default function TeamDetailsPage(): JSX.Element {
                         Sports Hall Location
                       </p>
                     </div>
-                    <span className='rounded-full bg-yellow-100 px-3 py-1 text-xs font-medium text-yellow-800'>
+                    <span className='rounded-full bg-yellow-100 px-3 py-1 text-xs font-medium text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300'>
                       Scheduled
                     </span>
                   </div>
                 </div>
 
-                <div className='rounded-lg border border-gray-200 bg-gray-50 p-4'>
+                <div className='rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-700'>
                   <div className='flex items-center justify-between'>
                     <div>
                       <p className='font-medium'>vs Another Team</p>
@@ -142,7 +147,7 @@ export default function TeamDetailsPage(): JSX.Element {
                       </p>
                       <p className='text-foreground-lighter text-sm'>Main Court</p>
                     </div>
-                    <span className='rounded-full bg-green-100 px-3 py-1 text-xs font-medium text-green-800'>
+                    <span className='rounded-full bg-green-100 px-3 py-1 text-xs font-medium text-green-800 dark:bg-green-900/40 dark:text-green-300'>
                       Confirmed
                     </span>
                   </div>
@@ -151,7 +156,7 @@ export default function TeamDetailsPage(): JSX.Element {
             </div>
 
             {/* Recent Results */}
-            <div className='rounded-lg border border-gray-200 bg-white p-6 shadow-sm'>
+            <div className={cardClass}>
               <h2
                 className={cn(
                   'mb-4 text-xl font-semibold',
@@ -160,9 +165,11 @@ export default function TeamDetailsPage(): JSX.Element {
               >
                 📊 Recent Results
               </h2>
-              <div className='rounded-lg border border-green-200 bg-green-50 p-4'>
-                <p className='font-medium text-green-800'>🚧 Coming Soon!</p>
-                <p className='mt-1 text-sm text-green-700'>
+              <div className='rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-700 dark:bg-green-900/40'>
+                <p className='font-medium text-green-800 dark:text-green-300'>
+                  🚧 Coming Soon!
+                </p>
+                <p className='mt-1 text-sm text-green-700 dark:text-green-300'>
                   Match results and statistics will be displayed here.
                 </p>
               </div>
@@ -172,7 +179,7 @@ export default function TeamDetailsPage(): JSX.Element {
           {/* Sidebar - Team Info & Stats */}
           <div className='space-y-6'>
             {/* Team Info Card */}
-            <div className='rounded-lg border border-gray-200 bg-white p-6 shadow-sm'>
+            <div className={cardClass}>
               <h3
                 className={cn(
                   'mb-4 text-lg font-semibold',
@@ -214,7 +221,7 @@ export default function TeamDetailsPage(): JSX.Element {
             </div>
 
             {/* Season Stats */}
-            <div className='rounded-lg border border-gray-200 bg-white p-6 shadow-sm'>
+            <div className={cardClass}>
               <h3
                 className={cn(
                   'mb-4 text-lg font-semibold',
@@ -241,15 +248,15 @@ export default function TeamDetailsPage(): JSX.Element {
                   <span className='text-sm font-medium'>--</span>
                 </div>
               </div>
-              <div className='mt-4 rounded-lg bg-gray-50 p-3'>
-                <p className='text-xs text-gray-600'>
+              <div className='mt-4 rounded-lg bg-gray-50 p-3 dark:bg-gray-700'>
+                <p className='text-xs text-gray-600 dark:text-gray-300'>
                   Stats will be calculated automatically from game results.
                 </p>
               </div>
             </div>
 
             {/* Quick Actions */}
-            <div className='rounded-lg border border-gray-200 bg-white p-6 shadow-sm'>
+            <div className={cardClass}>
               <h3
                 className={cn(
                   'mb-4 text-lg font-semibold',
@@ -261,19 +268,19 @@ export default function TeamDetailsPage(): JSX.Element {
               <div className='space-y-3'>
                 <button
                   disabled
-                  className='text-foreground-lighter w-full cursor-not-allowed rounded-lg bg-gray-100 px-3 py-2 text-start text-sm'
+                  className='text-foreground-lighter w-full cursor-not-allowed rounded-lg bg-gray-100 px-3 py-2 text-start text-sm dark:bg-gray-700'
                 >
                   📅 View Full Schedule
                 </button>
                 <button
                   disabled
-                  className='text-foreground-lighter w-full cursor-not-allowed rounded-lg bg-gray-100 px-3 py-2 text-start text-sm'
+                  className='text-foreground-lighter w-full cursor-not-allowed rounded-lg bg-gray-100 px-3 py-2 text-start text-sm dark:bg-gray-700'
                 >
                   📊 View Statistics
                 </button>
                 <button
                   disabled
-                  className='text-foreground-lighter w-full cursor-not-allowed rounded-lg bg-gray-100 px-3 py-2 text-start text-sm'
+                  className='text-foreground-lighter w-full cursor-not-allowed rounded-lg bg-gray-100 px-3 py-2 text-start text-sm dark:bg-gray-700'
                 >
                   👥 View Players
                 </button>

--- a/app/routes/teams/teams.$teamId.tsx
+++ b/app/routes/teams/teams.$teamId.tsx
@@ -80,7 +80,7 @@ export default function TeamDetailsPage(): JSX.Element {
   const { i18n } = useTranslation()
 
   const cardClass =
-    'rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800'
+    'rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gradient-to-b dark:from-gray-800 dark:to-gray-900 dark:text-gray-100'
 
   return (
     <div className='min-h-screen'>
@@ -212,7 +212,7 @@ export default function TeamDetailsPage(): JSX.Element {
                     Status
                   </dt>
                   <dd>
-                    <span className='inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800'>
+                    <span className='inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/40 dark:text-green-300'>
                       Active
                     </span>
                   </dd>

--- a/app/routes/teams/teams._index.tsx
+++ b/app/routes/teams/teams._index.tsx
@@ -56,10 +56,13 @@ export default function PublicTeamsIndexPage(): JSX.Element {
     navigate(`/teams/${teamId}`)
   }
 
+  const cardClass =
+    'rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800'
+
   return (
     <div className='space-y-6' data-testid='teams-layout'>
       {/* Tournament Filter */}
-      <div className='rounded-lg border border-gray-200 bg-white p-6 shadow-sm'>
+      <div className={cardClass}>
         <TournamentFilter
           tournamentListItems={tournamentListItems}
           selectedTournamentId={selectedTournamentId}
@@ -97,7 +100,7 @@ export default function PublicTeamsIndexPage(): JSX.Element {
 
       {/* Info Section */}
       {teamListItems.length === 0 ? (
-        <div className='mt-8 rounded-lg bg-blue-50 p-6'>
+        <div className='mt-8 rounded-lg bg-blue-50 p-6 dark:bg-blue-900/40'>
           <h3 className={cn('text-lg font-medium', getLatinTitleClass(i18n.language))}>
             {t('teams.getStarted.title')}
           </h3>

--- a/app/routes/teams/teams._index.tsx
+++ b/app/routes/teams/teams._index.tsx
@@ -57,7 +57,7 @@ export default function PublicTeamsIndexPage(): JSX.Element {
   }
 
   const cardClass =
-    'rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800'
+    'rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gradient-to-b dark:from-gray-800 dark:to-gray-900 dark:text-gray-100'
 
   return (
     <div className='space-y-6' data-testid='teams-layout'>
@@ -104,7 +104,7 @@ export default function PublicTeamsIndexPage(): JSX.Element {
           <h3 className={cn('text-lg font-medium', getLatinTitleClass(i18n.language))}>
             {t('teams.getStarted.title')}
           </h3>
-          <p className='text-foreground-light mt-2'>
+          <p className='text-foreground-light mt-2 dark:text-blue-100'>
             {t('teams.getStarted.description')}
           </p>
         </div>


### PR DESCRIPTION
## Summary
- add dark-friendly container styles for admin panel and team routes
- ensure accent colors work in dark mode
- update tournament admin listing for dark scheme

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_685e74d465448323ad1a74a953725483